### PR TITLE
Comment report confirm has been added to preferences

### DIFF
--- a/app/migrations_preferences/0007_auto__add_field_sitepreferences_comment_report_confirm.py
+++ b/app/migrations_preferences/0007_auto__add_field_sitepreferences_comment_report_confirm.py
@@ -1,0 +1,85 @@
+# -*- coding: utf-8 -*-
+from south.utils import datetime_utils as datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        # Adding field 'SitePreferences.comment_report_confirm'
+        db.add_column('preferences_sitepreferences', 'comment_report_confirm',
+                      self.gf('ckeditor.fields.RichTextField')(null=True, blank=True),
+                      keep_default=False)
+
+
+    def backwards(self, orm):
+        # Deleting field 'SitePreferences.comment_report_confirm'
+        db.delete_column('preferences_sitepreferences', 'comment_report_confirm')
+
+
+    models = {
+        'auth.group': {
+            'Meta': {'object_name': 'Group'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '80'}),
+            'permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'})
+        },
+        'auth.permission': {
+            'Meta': {'ordering': "('content_type__app_label', 'content_type__model', 'codename')", 'unique_together': "(('content_type', 'codename'),)", 'object_name': 'Permission'},
+            'codename': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'content_type': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['contenttypes.ContentType']"}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '50'})
+        },
+        'auth.user': {
+            'Meta': {'object_name': 'User'},
+            'date_joined': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'email': ('django.db.models.fields.EmailField', [], {'max_length': '75', 'blank': 'True'}),
+            'first_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'groups': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['auth.Group']", 'symmetrical': 'False', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'is_staff': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_superuser': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'last_login': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'last_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'password': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'user_permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'}),
+            'username': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '30'})
+        },
+        'contenttypes.contenttype': {
+            'Meta': {'ordering': "('name',)", 'unique_together': "(('app_label', 'model'),)", 'object_name': 'ContentType', 'db_table': "'django_content_type'"},
+            'app_label': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'model': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        },
+        'preferences.preferences': {
+            'Meta': {'object_name': 'Preferences'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'sites': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'to': "orm['sites.Site']", 'null': 'True', 'blank': 'True'})
+        },
+        'preferences.sitepreferences': {
+            'Meta': {'object_name': 'SitePreferences', '_ormbases': ['preferences.Preferences']},
+            'about': ('ckeditor.fields.RichTextField', [], {'null': 'True', 'blank': 'True'}),
+            'comment_banned_patterns': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'comment_report_confirm': ('ckeditor.fields.RichTextField', [], {'null': 'True', 'blank': 'True'}),
+            'comment_silenced_patterns': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'comment_terms': ('ckeditor.fields.RichTextField', [], {'null': 'True', 'blank': 'True'}),
+            'commenting_time_off': ('django.db.models.fields.TimeField', [], {'null': 'True', 'blank': 'True'}),
+            'commenting_time_on': ('django.db.models.fields.TimeField', [], {'null': 'True', 'blank': 'True'}),
+            'contact_email_recipients': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'to': "orm['auth.User']", 'null': 'True', 'blank': 'True'}),
+            'preferences_ptr': ('django.db.models.fields.related.OneToOneField', [], {'to': "orm['preferences.Preferences']", 'unique': 'True', 'primary_key': 'True'}),
+            'terms': ('ckeditor.fields.RichTextField', [], {'null': 'True', 'blank': 'True'})
+        },
+        'sites.site': {
+            'Meta': {'ordering': "('domain',)", 'object_name': 'Site', 'db_table': "'django_site'"},
+            'domain': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '50'})
+        }
+    }
+
+    complete_apps = ['preferences']

--- a/app/models.py
+++ b/app/models.py
@@ -161,6 +161,10 @@ class SitePreferences(Preferences):
         blank=True,
         null=True
     )
+    comment_report_confirm = RichTextField(
+        blank=True,
+        null=True
+    )
     contact_email_recipients = models.ManyToManyField(
         'auth.User',
         blank=True,

--- a/locale/en/LC_MESSAGES/django.po
+++ b/locale/en/LC_MESSAGES/django.po
@@ -582,3 +582,6 @@ msgstr "Mobile number"
 
 #~ msgid "Back to sign up page"
 #~ msgstr "Back to sign up page"
+
+msgid "Report Comment"
+msgstr "Report Comment"

--- a/locale/fr/LC_MESSAGES/django.po
+++ b/locale/fr/LC_MESSAGES/django.po
@@ -569,3 +569,7 @@ msgstr "numéro de téléphone"
 
 #~ msgid "This is a translation"
 #~ msgstr "French Angielski"
+
+
+msgid "Report Comment"
+msgstr "Rapport Commentaire"

--- a/project/templates/app/mobi/app/includes/comments_new_system.html
+++ b/project/templates/app/mobi/app/includes/comments_new_system.html
@@ -7,7 +7,7 @@
 {% if user.profile.ban_duration == 1 %}
     <b>{% trans "You are banned from commenting for the rest of the day because a comment you made was reported by the community. You will be able to comment again tomorrow" %}</b><br><br/>
 
-    {% trans "Don't know why your comment was reported?" %} <a href="{% url comment-terms %}">{% trans "Read them here" 5}</a>
+    {% trans "Don't know why your comment was reported?" %} <a href="{% url comment-terms %}">{% trans "Read them here" %}</a>
 
 {% else %}
     <b>{% trans "You are banned from commenting for" %} {{ user.profile.ban_duration }} {% trans "days because a comment you made was reported by a MAMA Moderator" %}</b><br><br/>

--- a/project/templates/app/mobi/moderator/inclusion_tags/confirm_report_comment.html
+++ b/project/templates/app/mobi/moderator/inclusion_tags/confirm_report_comment.html
@@ -7,7 +7,7 @@
 <div class="padded-page">
     <h3>{% trans "Report Comment" %}</h3>
     {{ preferences.SitePreferences.comment_report_confirm|safe }}
-    Don't know the commenting rules? <a href="{% url comment-terms %}">Read them here</a><br><br/>
+    {% trans "Don't know the commenting rules?" %} <a href="{% url comment-terms %}">{% trans "Read them here" %}</a><br><br/>
 
     {% report_comment_abuse comment %}
 </div>

--- a/project/templates/app/mobi/moderator/inclusion_tags/confirm_report_comment.html
+++ b/project/templates/app/mobi/moderator/inclusion_tags/confirm_report_comment.html
@@ -1,17 +1,12 @@
 {% extends 'base.html' %}
 {% load mama_inclusion_tags %}
 {% load moderator_inclusion_tags %}
+{% load i18n %}
 
 {% block content %}
 <div class="padded-page">
-    <h3>Report Comment</h3>
-    <b>Thanks for keeping MAMA clean! </b><br><br/>
-    <b>Are you sure you want to report this comment?  </b><br><br/>
-       The user will be banned for 1 day if you report this comment. <br><br/>
-    <b>You should only report a comment if it is contains one of the following:</b>
-    swear words, dirty words, sexy-talk, pick-ups,come-ons, rudeness, abusiveness, racism, sexism, a users is
-    forcing their religious beliefs on others or posting phone
-    numbers or email address in the comments stream.<br><br/>
+    <h3>{% trans "Report Comment" %}</h3>
+    {{ preferences.SitePreferences.comment_report_confirm|safe }}
     Don't know the commenting rules? <a href="{% url comment-terms %}">Read them here</a><br><br/>
 
     {% report_comment_abuse comment %}


### PR DESCRIPTION
Comment report confirm is now added to preferences and kept dynamic now. Now we could apply translation content for the same.
