### PR TITLE
remove facebook and twitter meta tags for images

### DIFF
--- a/app/tests/test_app.py
+++ b/app/tests/test_app.py
@@ -444,7 +444,7 @@ class GeneralPrefrencesTestCase(TestCase):
             '<meta property="og:title" content="Test" />')
         self.assertContains(
             response,
-            '<meta property="og:url" content="/content/detail/test/">')
+            '<meta property="og:url" content="http://testserver/content/detail/test/">')
         self.assertContains(
             response,
             '<meta property="og:description" content="the subtitle" />')

--- a/project/templates/app/mobi/post/post_category_detail.html
+++ b/project/templates/app/mobi/post/post_category_detail.html
@@ -13,9 +13,6 @@
 <meta name="twitter:card" content="summary_large_image" />
 <meta name="twitter:title" content="{{ object.title }}">
 <meta name="twitter:description" content="{{ object.subtitle }}">
-{% if object.image %}
-  <meta property="twitter:image" content="{{ object.get_large_url }}" />
-{% endif %}
 <!-- /Twitter -->
 
 <!-- Facebook: Open Graph tags -->
@@ -23,9 +20,6 @@
 <meta property="og:url" content="{{ object.get_absolute_url }}">
 {% if object.subtitle %}
   <meta property="og:description" content="{{ object.subtitle }}" />
-{% endif %}
-{% if object.image %}
-  <meta property="og:image" content="{{ object.get_large_url }}" />
 {% endif %}
 <!-- /Facebook -->
 

--- a/project/templates/app/mobi/post/post_category_detail.html
+++ b/project/templates/app/mobi/post/post_category_detail.html
@@ -13,13 +13,19 @@
 <meta name="twitter:card" content="summary_large_image" />
 <meta name="twitter:title" content="{{ object.title }}">
 <meta name="twitter:description" content="{{ object.subtitle }}">
+{% if object.image %}
+  <meta property="twitter:image" content="http{% if request.is_secure %}s{% endif %}://{{ request.get_host }}{{ object.get_large_url }}" />
+{% endif %}
 <!-- /Twitter -->
 
 <!-- Facebook: Open Graph tags -->
 <meta property="og:title" content="{{ object.title }}" />
-<meta property="og:url" content="{{ object.get_absolute_url }}">
+<meta property="og:url" content="http{% if request.is_secure %}s{% endif %}://{{ request.get_host }}{{ object.get_absolute_url }}">
 {% if object.subtitle %}
   <meta property="og:description" content="{{ object.subtitle }}" />
+{% endif %}
+{% if object.image %}
+  <meta property="og:image" content="http{% if request.is_secure %}s{% endif %}://{{ request.get_host }}{{ object.get_large_url }}" />
 {% endif %}
 <!-- /Facebook -->
 


### PR DESCRIPTION
removed the meta tags specifiying the image to pull in an attempt to get facebook and twitter to automatically identify the images
